### PR TITLE
Fix parsing of Lists as AnnotatedPreterms #32

### DIFF
--- a/src/main/java/typed/ski/deep/typechecker/TypeChecker.java
+++ b/src/main/java/typed/ski/deep/typechecker/TypeChecker.java
@@ -202,7 +202,7 @@ public class TypeChecker {
                 unknownTypes = unify(typeEquations, unknownTypes);
                 pair.getLeft().substituteUnknownTypes(unknownTypes);
 
-                return Optional.of(Pair.of(pair.getLeft(), replaceTypeIfUnknown(pair.getRight(), unknownTypes)));
+                return Optional.of(Pair.of(pair.getLeft(), ((AnnotatedPreterm) parseTree).getType()));
             }
 
             throw new TypeCheckerException("Could not infer the type of preterm: \"" + ((AnnotatedPreterm) parseTree).getPreterm().toString() + "\"");

--- a/src/main/resources/definitions.txt
+++ b/src/main/resources/definitions.txt
@@ -9,3 +9,6 @@ FAC=((Rec (Succ ZERO)) ((B MUL) Succ));
 CASE=C (B B Rec) (B K);
 ITER=C (B B Rec) K;
 LE_ITER=ITER (K True) (CASE False);
+AND=C (B C ITE) False;
+OR=C ITE True;
+listSize=RecList ZERO (B (K (K Succ)) I);  <- ha az input [], meg kell adni RecList type paramétereit, A: lista type param, B: zero elem


### PR DESCRIPTION
 - Fix type check of AnnotatedPreterms
 - AND, OR and listSize combinators added to definitions